### PR TITLE
Scan full directory; output multiple TRAP files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 .rspec_status
 
 .cache/
+
+TODOS.md

--- a/README.md
+++ b/README.md
@@ -6,7 +6,21 @@ This repo contains tools and example queries to use [CodeQL](https://securitylab
 - an [extractor](https://help.semmle.com/codeql/glossary.html#extractor) to generate a [CodeQL database](https://help.semmle.com/codeql/about-codeql.html#about-codeql-databases) from a Ruby codebase
 - a [CodeQL library](https://help.semmle.com/QL/ql-handbook/modules.html#library-modules) for the Ruby language to allow easy querying
 
-It is currently in **proof-of-concept** stage. Not only should you not use this in production, it's currently unusable for research. This will be updated as we get this thing off the ground, but for now it is only online as a demonstration and to allow anyone who would like to to try it out, fork it, or contribute their own code.
+## Proof of Concept
+
+This tool is currently in **proof-of-concept** stage. Not only should you not use this in production, it's currently unusable for research. This will be updated as we get this thing off the ground, but for now it is only online as a demonstration and to allow anyone who would like to to try it out, fork it, or contribute their own code.
+
+Progress will be tracked on [agius/codeql_ruby](https://github.com/agius/codeql_ruby), and you can follow it via:
+
+- [Pull requests](https://github.com/agius/codeql_ruby/pulls) for all code changes
+
+- [Github Projects on this repo](https://github.com/agius/codeql_ruby/projects) - currently on [Phase 2: Usefulness](https://github.com/agius/codeql_ruby/projects/1)
+
+If you have specific thoughts, suggestions, proposals, use cases, etc, please feel free to contact the maintainers:
+
+- [open an issue](https://github.com/agius/codeql_ruby/issues/new) on [agius/codeql_ruby](https://github.com/agius/codeql_ruby) 
+- [tweet at @agius](http://twitter.com/agius)
+- join us in the `#codeql-hacking` channel in the Github Security Lab Slack team - request an invite on [the Github Security Lab page](https://securitylab.github.com/get-involved)
 
 ## Dependencies
 
@@ -75,9 +89,15 @@ With that, you should be good to go! Check out "Usage" and "Development" below.
 
 ## Usage
 
-Currently the extractor only extracts one file: `spec/base_unsafe_script/unsafe_command.rb` 
+Currently the extractor extracts all Ruby files nested in the directory from which the extractor is run. Essentially all files found by:
 
-You can create a database for this file by using the codeql create database functionality:
+```shell
+$ find . -name '*.rb'
+```
+
+Expanding extraction to dependencies and related files is a work-in-progress.
+
+You can create a database for the directory by using the codeql create database functionality:
 
 ```shell
 $ codeql database create ~/codeql-home/example-ruby-db --language=ruby

--- a/exe/codeql_ruby
+++ b/exe/codeql_ruby
@@ -17,4 +17,4 @@ require "codeql_ruby"
 # CODEQL_EXTRACTOR_RUBY_TRAP_DIR=<db_dir>/trap/ruby
 # JAVA_MAIN_CLASS_50625=com.semmle.cli2.CodeQL
 
-CodeqlRuby.extract
+CodeqlRuby.extract ARGV.first

--- a/extractor/ruby.dbscheme
+++ b/extractor/ruby.dbscheme
@@ -1,5 +1,67 @@
 /** dbscheme for Ruby, feel free to edit. I don't know what I'm doing ^_^; */
 
+/* Filesystem fragments specified as part of the extractor contract */
+
 sourceLocationPrefix(varchar(900) prefix : string ref);
 
-leaf_nodes(unique int id: @leaf_node, string text: string ref, int beginLine: int ref, int beginColumn: int ref)
+@location = @location_default /* TODO add alternatives */;
+
+locations_default(
+  unique int id:    @location_default,
+  int file:         @file ref,
+  int beginLine:    int ref,
+  int beginColumn:  int ref,
+  int endLine:      int ref,
+  int endColumn:    int ref
+);
+
+has_location(
+  unique int locatable: @locatable ref,
+  int location:         @location ref
+);
+
+@sourceline = @file /* TODO add alternatives */;
+
+numlines(
+  int element_id:   @sourceline ref,
+  int num_lines:    int ref,
+  int num_code:     int ref,
+  int num_comment:  int ref
+);
+
+/*
+  fromSource(0) = unknown,
+  fromSource(1) = from source,
+  fromSource(2) = from library
+*/
+files(
+  unique int id:        @file,
+  varchar(900) name:    string ref,
+  varchar(900) simple:  string ref,
+  varchar(900) ext:     string ref,
+  int fromSource:       int ref
+);
+
+folders(
+  unique int id:        @folder,
+  varchar(900) name:    string ref,
+  varchar(900) simple:  string ref
+);
+
+@container = @folder | @file ;
+
+containerparent(
+  int parent:       @container ref,
+  unique int child: @container ref
+);
+
+/* Ruby AST Stuff */
+
+leaf_nodes(
+  unique int id:    @leaf_node,
+  string text:      string ref,
+  int beginLine:    int ref,
+  int beginColumn:  int ref
+);
+
+@locatable = @leaf_node;

--- a/lib/codeql_ruby.rb
+++ b/lib/codeql_ruby.rb
@@ -1,12 +1,15 @@
-require "codeql_ruby/version"
-require "codeql_ruby/extractor"
+require 'codeql_ruby/version'
+require 'codeql_ruby/node'
+require 'codeql_ruby/visitor'
+require 'codeql_ruby/extractor_file'
+require 'codeql_ruby/extractor'
 
 module CodeqlRuby
   class Error < StandardError; end
 
   module_function
 
-  def extract
-    Extractor.new.extract!
+  def extract(file_or_dir = nil)
+    Extractor.new(file_or_dir).extract!
   end
 end

--- a/lib/codeql_ruby/extractor_file.rb
+++ b/lib/codeql_ruby/extractor_file.rb
@@ -1,0 +1,90 @@
+require 'forwardable'
+
+module CodeqlRuby
+  class ExtractorFile
+
+    extend Forwardable
+
+    # allow ExtractorFile to be sorted and unique'd based on filepath string
+    def_delegator :@filepath, :hash
+
+    attr_reader :filepath, :source_kind
+
+    # these should be kept in sync with files#fromSource in ruby.dbscheme
+    SOURCE_KINDS = {
+      unknown: 0,
+      source: 1,
+      library: 2
+    }.freeze
+
+    def self.source_kinds
+      SOURCE_KINDS
+    end
+
+    def initialize(filepath, source_kind: nil)
+      @filepath = filepath
+      @source_kind = source_kind || :source
+    end
+
+    # allow ExtractorFile to be sorted and unique'd based on filepath string
+    def eql?(other)
+      @filepath.eql?(other)
+    end
+
+    def contents
+      @contents ||= File.read(filepath)
+    end
+
+    def trapfile_name
+      @trapfile_name ||= "#{File.basename(filepath, '.rb')}.trap"
+    end
+
+    def structure
+      @structure ||= begin
+        Node.new(Ripper.sexp(contents))
+      end
+    end
+
+    # https://youtu.be/b8m9zhNAgKs?t=44
+    def to_trap
+      trapout = []
+      idx = 10_000
+
+      folders = Pathname.new(filepath).ascend.to_a.reverse[0..-2]
+      prev = nil
+      folders.each do |paf|
+        simple = File.basename(paf)
+        trapout << "##{idx}=@\"#{paf};folder\""
+        trapout << "folders(##{idx}, \"#{paf}\", \"#{simple}\")"
+        trapout << "containerparent(##{prev},##{idx})" if prev
+        prev = idx
+        idx += 1
+      end
+
+      file_ref = idx
+      trapout << "##{file_ref}=@\"#{filepath};sourcefile\""
+
+      basename = File.basename(filepath, '.*')
+      extname = File.extname(filepath)
+      extname = extname[1..-1] if extname.start_with?('.')
+      src_kind = SOURCE_KINDS[source_kind]
+
+      trapout << "files(##{file_ref},\"#{filepath}\",\"#{basename}\",\"#{extname}\",#{src_kind})"
+      trapout << "containerparent(##{prev}, ##{file_ref})"
+
+      idx += 1
+      loc_ref = idx
+      trapout << "##{loc_ref}=@\"loc,{##{file_ref}},0,0,0,0\""
+      trapout << "locations_default(##{loc_ref}, ##{file_ref}, 0, 0, 0, 0)"
+
+      visitor = Visitor.new(idx, file_ref)
+      visitor.visit(structure)
+      trapout += visitor.trap_entries
+
+      num_lines = contents.count("\n")
+
+      trapout << "numlines(##{prev}, #{num_lines}, #{visitor.num_code}, #{visitor.num_comment})"
+      trapout.join("\n")
+    end
+  end
+end

--- a/lib/codeql_ruby/node.rb
+++ b/lib/codeql_ruby/node.rb
@@ -1,0 +1,49 @@
+module CodeqlRuby
+  class Node
+    attr_reader :sexp, :children
+
+    def initialize(sexp)
+      @sexp = sexp
+      @children = if leaf_node?
+        []
+      else
+        Array(sexp).map { |item| Node.new(item) if item.is_a?(Array) }.compact
+      end
+    end
+
+    def children?
+      !children.empty?
+    end
+
+    def start_line
+      return nil unless leaf_node?
+
+      sexp[2][0]
+    end
+
+    def end_line
+      start_line
+    end
+
+    def start_col
+      return nil unless leaf_node?
+
+      sexp[2][1]
+    end
+
+    def end_col
+      return nil unless leaf_node?
+
+      start_col + sexp[1].size
+    end
+
+    def leaf_node?
+      return @leaf_node unless @leaf_node.nil?
+
+      @leaf_node = sexp.is_a?(Array) &&
+        sexp[0].is_a?(Symbol) &&
+        sexp[1].is_a?(String) &&
+        sexp[2].is_a?(Array) && sexp[2].size == 2
+    end
+  end
+end

--- a/lib/codeql_ruby/visitor.rb
+++ b/lib/codeql_ruby/visitor.rb
@@ -1,0 +1,43 @@
+module CodeqlRuby
+  class Visitor
+
+    IDX_START = 10_000
+
+    attr_reader :idx, :trap_entries, :num_code, :num_comment, :file_ref
+
+    def initialize(idx_start, file_ref)
+      @idx = idx_start
+      @file_ref = file_ref
+      @num_code = 0
+      @num_comment = 0
+      @trap_entries = []
+    end
+
+    def visit(node)
+      @num_code += 1
+      if node.leaf_node?
+        @trap_entries += trap_for_leaf(node)
+      else
+        node.children.each { |child| visit(child) }
+      end
+      @trap_entries
+    end
+
+    def trap_for_leaf(node)
+      trapper_keeper = []
+
+      @idx += 1
+      leaf_idx = idx
+      trapper_keeper << "##{leaf_idx}=*"
+
+      @idx += 1
+      loc_idx = idx
+
+      trapper_keeper << "##{loc_idx}=@\"loc,{##{file_ref}},#{node.start_line},#{node.start_col},#{node.end_line},#{node.end_col}\""
+      trapper_keeper << "locations_default(##{loc_idx}, ##{file_ref}, #{node.start_line}, #{node.start_col}, #{node.end_line}, #{node.end_col})"
+      trapper_keeper << "has_location(##{leaf_idx}, ##{loc_idx})"
+      trapper_keeper << "leaf_nodes(##{leaf_idx}, \"#{node.sexp[1]}\", #{node.start_line}, #{node.start_col})"
+      trapper_keeper
+    end
+  end
+end

--- a/ql/src/ruby.dbscheme
+++ b/ql/src/ruby.dbscheme
@@ -1,5 +1,67 @@
 /** dbscheme for Ruby, feel free to edit. I don't know what I'm doing ^_^; */
 
+/* Filesystem fragments specified as part of the extractor contract */
+
 sourceLocationPrefix(varchar(900) prefix : string ref);
 
-leaf_nodes(unique int id: @leaf_node, string text: string ref, int beginLine: int ref, int beginColumn: int ref)
+@location = @location_default /* TODO add alternatives */;
+
+locations_default(
+  unique int id:    @location_default,
+  int file:         @file ref,
+  int beginLine:    int ref,
+  int beginColumn:  int ref,
+  int endLine:      int ref,
+  int endColumn:    int ref
+);
+
+has_location(
+  unique int locatable: @locatable ref,
+  int location:         @location ref
+);
+
+@sourceline = @file /* TODO add alternatives */;
+
+numlines(
+  int element_id:   @sourceline ref,
+  int num_lines:    int ref,
+  int num_code:     int ref,
+  int num_comment:  int ref
+);
+
+/*
+  fromSource(0) = unknown,
+  fromSource(1) = from source,
+  fromSource(2) = from library
+*/
+files(
+  unique int id:        @file,
+  varchar(900) name:    string ref,
+  varchar(900) simple:  string ref,
+  varchar(900) ext:     string ref,
+  int fromSource:       int ref
+);
+
+folders(
+  unique int id:        @folder,
+  varchar(900) name:    string ref,
+  varchar(900) simple:  string ref
+);
+
+@container = @folder | @file ;
+
+containerparent(
+  int parent:       @container ref,
+  unique int child: @container ref
+);
+
+/* Ruby AST Stuff */
+
+leaf_nodes(
+  unique int id:    @leaf_node,
+  string text:      string ref,
+  int beginLine:    int ref,
+  int beginColumn:  int ref
+);
+
+@locatable = @leaf_node;

--- a/spec/codeql_ruby_spec.rb
+++ b/spec/codeql_ruby_spec.rb
@@ -11,4 +11,12 @@ RSpec.describe CodeqlRuby do
 
     expect(tuples).to include(['eval', 'This is a leaf node.'])
   end
+
+  it "extracts a file to relevant trap structures" do
+    filepath = File.expand_path(File.join(File.dirname(__FILE__), 'script_with_require', 'script_with_require.rb'))
+    ef = CodeqlRuby::ExtractorFile.new(filepath)
+    results = ef.to_trap
+
+    expect(results).to be_a(String)
+  end
 end

--- a/spec/codeql_ruby_spec.rb
+++ b/spec/codeql_ruby_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe CodeqlRuby do
     expect(tuples).to include(['eval', 'This is a leaf node.'])
   end
 
+  it "extracts a directory as a db and queries it" do
+    results = CodeqlRunner.results_for_db('script_with_require')
+    tuples = results.dig('#select', 'tuples')
+
+    expect(tuples).to include(['RequiredFile', 'This is a leaf node.'])
+  end
+
   it "extracts a file to relevant trap structures" do
     filepath = File.expand_path(File.join(File.dirname(__FILE__), 'script_with_require', 'script_with_require.rb'))
     ef = CodeqlRuby::ExtractorFile.new(filepath)

--- a/spec/script_with_require/example.ql
+++ b/spec/script_with_require/example.ql
@@ -1,0 +1,11 @@
+/**
+ * @name Script contains stuff
+ * @kind problem
+ * @problem.severity oh-t3h-n0es!!11!!1one!!
+ * @id ruby/spec/script-with-require
+ */
+
+import ruby
+
+from LeafNode n
+select n.getText(), "This is a leaf node."

--- a/spec/script_with_require/qlpack.yml
+++ b/spec/script_with_require/qlpack.yml
@@ -1,0 +1,3 @@
+name: ruby-script-with-require
+version: 0.0.0
+libraryPathDependencies: codeql-ruby

--- a/spec/script_with_require/required_file.rb
+++ b/spec/script_with_require/required_file.rb
@@ -1,0 +1,7 @@
+class RequiredFile
+  attr_reader :fullpath
+
+  def initialize
+    @fullpath = File.expand_path(__FILE__)
+  end
+end

--- a/spec/script_with_require/script_with_require.rb
+++ b/spec/script_with_require/script_with_require.rb
@@ -1,0 +1,4 @@
+require_relative './required_file'
+
+rf = RequiredFile.new
+puts rf.fullpath


### PR DESCRIPTION
- Adds support for extracting all (nested) Ruby files in a directory to separate TRAP files. 
- Adds representation of source code location as part of TRAP output.
- Adds spec for parsing files with `require` syntax